### PR TITLE
Rename get_ssm_by_sample arg to this_sample_id

### DIFF
--- a/R/get_ssm_by_samples.R
+++ b/R/get_ssm_by_samples.R
@@ -6,9 +6,10 @@
 #' Either specify the sample IDs of interest with `these_sample_ids`.
 #' Or a metadata table subset to the sample IDs of interest with `these_samples_metadata`.
 #'
-#' @param these_sample_ids The sample_id you want the data from.
+#' @param this_sample_id A single sample ID you want the data from.
+#' @param these_sample_ids A vector of sample IDs that you want results for.
 #' @param these_samples_metadata Optional, a metadata table (with sample IDs in a column) to auto-subset the data to samples in that table before returning.
-#' If not not provided and these_sample_ids is also not provided, the function will return SSM for all samples from the specified seq_type in the bundled metadata.
+#' If not provided and these_sample_ids is also not provided, the function will return SSM for all samples from the specified seq_type in the bundled metadata.
 #' @param this_seq_type Default is genome.
 #' @param projection The projection genome build. Supports hg38 and grch37.
 #' @param these_genes A vector of genes to subset ssm to.
@@ -96,9 +97,30 @@ get_ssm_by_samples <- function(these_sample_ids = NULL,
 #' @rdname get_ssm_by_samples
 #' 
 #' @examples
-#' #basic usage, using a sample ID
-#' dohh2_maf = get_ssm_by_samples(these_sample_ids = "DOHH-2")
+#' #basic usage, using a single sample ID
+#' dohh2_maf = get_ssm_by_sample(this_sample_id = "DOHH-2")
 #' 
 #' @export
 #' 
-get_ssm_by_sample <- get_ssm_by_samples
+get_ssm_by_sample = function(this_sample_id = NULL,
+                             these_samples_metadata = NULL,
+                             this_seq_type = "genome",
+                             projection = "grch37",
+                             these_genes,
+                             min_read_support = 3,
+                             basic_columns = TRUE,
+                             maf_cols = NULL,
+                             verbose = FALSE,
+                             ...){
+  
+  get_ssm_by_samples(these_sample_ids = this_sample_id,
+                     these_samples_metadata = NULL,
+                     this_seq_type = "genome",
+                     projection = "grch37",
+                     these_genes,
+                     min_read_support = 3,
+                     basic_columns = TRUE,
+                     maf_cols = NULL,
+                     verbose = FALSE,
+                     ...)
+}

--- a/man/get_ssm_by_samples.Rd
+++ b/man/get_ssm_by_samples.Rd
@@ -19,7 +19,7 @@ get_ssm_by_samples(
 )
 
 get_ssm_by_sample(
-  these_sample_ids = NULL,
+  this_sample_id = NULL,
   these_samples_metadata = NULL,
   this_seq_type = "genome",
   projection = "grch37",
@@ -32,10 +32,10 @@ get_ssm_by_sample(
 )
 }
 \arguments{
-\item{these_sample_ids}{The sample_id you want the data from.}
+\item{these_sample_ids}{A vector of sample IDs that you want results for.}
 
 \item{these_samples_metadata}{Optional, a metadata table (with sample IDs in a column) to auto-subset the data to samples in that table before returning.
-If not not provided and these_sample_ids is also not provided, the function will return SSM for all samples from the specified seq_type in the bundled metadata.}
+If not provided and these_sample_ids is also not provided, the function will return SSM for all samples from the specified seq_type in the bundled metadata.}
 
 \item{this_seq_type}{Default is genome.}
 
@@ -52,6 +52,8 @@ If not not provided and these_sample_ids is also not provided, the function will
 \item{verbose}{Enable for debugging/noisier output.}
 
 \item{...}{Any additional parameters.}
+
+\item{this_sample_id}{A single sample ID you want the data from.}
 }
 \value{
 data frame in MAF format.
@@ -74,7 +76,7 @@ cell_line_meta = GAMBLR.data::sample_data$meta \%>\%
   
 dlbcl_maf = get_ssm_by_samples(these_samples_metadata = cell_line_meta)
 
-#basic usage, using a sample ID
-dohh2_maf = get_ssm_by_samples(these_sample_ids = "DOHH-2")
+#basic usage, using a single sample ID
+dohh2_maf = get_ssm_by_sample(this_sample_id = "DOHH-2")
 
 }


### PR DESCRIPTION
In GAMBLR.results, `get_ssm_by_sample` uses `this_sample_id` (both singular) and `get_ssm_by_samples` uses `these_sample_ids` (both plural), which makes sense. In GAMBLR.data, `get_ssm_by_samples` does use `these_sample_ids`, but `get_ssm_by_sample` uses `these_sample_ids`

In this PR, I rename `get_ssm_by_sample`'s argument to `this_sample_id`.