### PR TITLE
Adding ashm variants and slsm-3 variants for published samples

### DIFF
--- a/R/get_ssm_by_patients.R
+++ b/R/get_ssm_by_patients.R
@@ -3,21 +3,22 @@
 #' @description Get MAF-format data frame for more than one patient.
 #'
 #' @details This function returns variants from a set of patients.
-#' This function internally calls [GAMBLR.data::get_ssm_by_samples]. 
-#' Thus, the main contents of this function is to wrangle the provided patient IDs, 
+#' This function internally calls [GAMBLR.data::get_ssm_by_samples].
+#' Thus, the main contents of this function is to wrangle the provided patient IDs,
 #' so that the corresponding sample IDs can be provided to the internal call of `get_ssm_by_samples`.
-#' This function expects either a vector of patient IDs (`these_patients_ids`) 
+#' This function expects either a vector of patient IDs (`these_patients_ids`)
 #' or an already subset metadata table (`these_samples_metadata`).
 #'
-#' @param these_patient_ids A vector of patient IDs that you want results for. 
+#' @param these_patient_ids A vector of patient IDs that you want results for.
 #' The user can also use a metadata table that has been subset to the patient IDs of interest (see `these_samples_metadata`).
-#' @param these_samples_metadata A metadata subset to contain the rows corresponding to the patients of interest. 
+#' @param these_samples_metadata A metadata subset to contain the rows corresponding to the patients of interest.
 #' If the vector of patient IDs is missing (`these_patient_ids`), this function will default to all patient IDs in the metadata table given to this parameter.
 #' @param projection Obtain variants projected to this reference (one of grch37 or hg38). Default is grch37.
 #' @param this_seq_type The seq type you want results for. Default is "genome".
+#' @param tool_name Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.
 #' @param min_read_support Subset returned variants to a set minimum read support. Default is 3.
 #' @param basic_columns Return first 45 columns of MAF rather than full details. Default is TRUE.
-#' @param maf_cols if basic_columns is set to FALSE, the user can specify what columns to be returned within the MAF. 
+#' @param maf_cols if basic_columns is set to FALSE, the user can specify what columns to be returned within the MAF.
 #' This parameter can either be a vector of indexes (integer) or a vector of characters (matching columns in MAF).
 #' @param verbose Set to FALSE to minimize the output to console. Default is TRUE. This parameter also dictates the verbosity of any helper function internally called inside the main function.
 #' @param ... Any additional parameters.
@@ -25,36 +26,37 @@
 #' @return A data frame with SSM calls for the selected patients in MAF format.
 #'
 #' @import dplyr
-#' 
+#'
 #' @export
 #'
 #' @examples
 #' #load packages
 #' library(dplyr)
-#' 
+#'
 #' #basic usage, these_patient_ids
 #' my_patient = get_ssm_by_patients(these_patient_ids = "DOHH-2")
 #'
 #' #using a subset metadata tablee to retreive patient SSMs
-#' cell_line_meta = GAMBLR.data::sample_data$meta %>% 
+#' cell_line_meta = GAMBLR.data::sample_data$meta %>%
 #'  dplyr::filter(cohort == "DLBCL_cell_lines")
-#'  
-#' patient_maf = get_ssm_by_patients(these_samples_metadata = cell_line_meta, 
+#'
+#' patient_maf = get_ssm_by_patients(these_samples_metadata = cell_line_meta,
 #'                                   this_seq_type = "genome")
 #'
 get_ssm_by_patients = function(these_patient_ids,
                                these_samples_metadata,
                                projection = "grch37",
                                this_seq_type = "genome",
+                               tool_name = "slms-3",
                                min_read_support = 3,
                                basic_columns = TRUE,
                                maf_cols = NULL,
                                verbose = FALSE,
                                ...){
-  
+
   #check if any invalid parameters are provided
   check_excess_params(...)
-  
+
   #figure out what patients the user wants
   if(missing(these_patient_ids)){
     if(missing(these_samples_metadata)){
@@ -70,11 +72,12 @@ get_ssm_by_patients = function(these_patient_ids,
     these_samples_metadata = these_samples_metadata %>%
       dplyr::filter(patient_id %in% these_patient_ids)
   }
-  
+
   #run get_ssm_by_samples with these_samples_metadata parameter
   return(GAMBLR.data::get_ssm_by_samples(these_samples_metadata = these_samples_metadata,
                                          projection = projection,
                                          this_seq_type = this_seq_type,
+                                         tool_name = tool_name,
                                          min_read_support = min_read_support,
                                          basic_columns = basic_columns,
                                          maf_cols = maf_cols,

--- a/R/get_ssm_by_region.R
+++ b/R/get_ssm_by_region.R
@@ -19,7 +19,7 @@
 #' @param streamlined Return Start_Position and Tumor_Smaple_Barcode as the only two MAF columns. Default is FALSE.
 #' @param projection Obtain variants projected to this reference (one of grch37 or hg38).
 #' @param this_seq_type The seq_type you want back, default is genome.
-#' @param mode Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".
+#' @param mode Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.
 #' @param min_read_support Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).
 #' @param verbose Set to FALSE to prevent ANY message to be printed.
 #' In most cases, this parameter should be left to TRUE.

--- a/R/get_ssm_by_region.R
+++ b/R/get_ssm_by_region.R
@@ -143,5 +143,9 @@ get_ssm_by_region = function(these_sample_ids = NULL,
       dplyr::select(Start_Position, Tumor_Sample_Barcode)
   }
 
+  # Handle possible duplicates
+  muts_region <- muts_region %>%
+    distinct
+
   return(muts_region)
 }

--- a/R/get_ssm_by_regions.R
+++ b/R/get_ssm_by_regions.R
@@ -11,7 +11,7 @@
 #' i.e the following parameters are ignored; `these_samples_metadata`, `these_sample_ids`, and `this_seq_type`
 #' If not provided (and if `these_sample_ids` is not provided), the function will return all samples from the specified seq_type in the metadata.
 #' @param this_seq_type The this_seq_type you want back, default is genome.
-#' @param mode Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".
+#' @param mode Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.
 #' @param regions_list A vector of regions in the chr:start-end format to restrict the returned SSM calls to.
 #' @param regions_bed A data frame in BED format with the coordinates you want to retrieve (recommended).
 #' This parameter can also accept an additional column with region names that will be added to the return if `use_name_column = TRUE`

--- a/R/get_ssm_by_regions.R
+++ b/R/get_ssm_by_regions.R
@@ -5,32 +5,33 @@
 #' @details This function internally calls [GAMBLR.data::get_ssm_by_region] to retrieve SSM calls for the specified regions.
 #'
 #' @param these_sample_ids Optional, a vector of multiple sample_id (or a single sample ID as a string) that you want results for.
-#' @param these_samples_metadata Optional, a metadata table (with sample IDs in a column) to subset the return to. 
-#' @param maf_data Optional data frame with mutations in MAF format. 
-#' If user provides a maf, the function trusts that the user has already subset this to samples of interest, correct seq_type. 
+#' @param these_samples_metadata Optional, a metadata table (with sample IDs in a column) to subset the return to.
+#' @param maf_data Optional data frame with mutations in MAF format.
+#' If user provides a maf, the function trusts that the user has already subset this to samples of interest, correct seq_type.
 #' i.e the following parameters are ignored; `these_samples_metadata`, `these_sample_ids`, and `this_seq_type`
 #' If not provided (and if `these_sample_ids` is not provided), the function will return all samples from the specified seq_type in the metadata.
 #' @param this_seq_type The this_seq_type you want back, default is genome.
+#' @param mode Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".
 #' @param regions_list A vector of regions in the chr:start-end format to restrict the returned SSM calls to.
-#' @param regions_bed A data frame in BED format with the coordinates you want to retrieve (recommended). 
-#' This parameter can also accept an additional column with region names that will be added to the return if `use_name_column = TRUE` 
-#' @param streamlined If set to TRUE (default) only 3 columns will be kept in the returned data frame (start, sample_id and region_name). 
+#' @param regions_bed A data frame in BED format with the coordinates you want to retrieve (recommended).
+#' This parameter can also accept an additional column with region names that will be added to the return if `use_name_column = TRUE`
+#' @param streamlined If set to TRUE (default) only 3 columns will be kept in the returned data frame (start, sample_id and region_name).
 #' @param use_name_column If your bed-format data frame has a name column (must be named "name") these can be used to name your regions in the returned data frame.
 #' @param projection Obtain variants projected to this reference (one of grch37 or hg38), default is grch37.
 #' @param min_read_support Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).
-#' @param verbose Set to TRUE to maximize the output to console. Default is TRUE. 
+#' @param verbose Set to TRUE to maximize the output to console. Default is TRUE.
 #' This parameter also dictates the verbosity of any helper function internally called inside the main function.
 #' @param ... Any additional parameters.
 #'
 #' @return Returns a data frame of variants in MAF-like format.
 #'
 #' @import tibble dplyr tidyr
-#' 
+#'
 #' @export
 #'
 #' @examples
 #' #basic usage, adding custom names from bundled ashm data frame
-#' regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, 
+#' regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions,
 #'   name = paste(gene, region, sep = "_"))
 #'
 #' ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed,
@@ -41,6 +42,7 @@ get_ssm_by_regions = function(these_sample_ids = NULL,
                               these_samples_metadata = NULL,
                               maf_data,
                               this_seq_type = "genome",
+                              mode = "slms-3",
                               regions_list,
                               regions_bed,
                               streamlined = TRUE,
@@ -49,14 +51,14 @@ get_ssm_by_regions = function(these_sample_ids = NULL,
                               min_read_support = 3,
                               verbose = FALSE,
                               ...){
-  
+
   #check if any invalid parameters are provided
   check_excess_params(...)
-  
+
   bed2region = function(x){
     paste0(x[1], ":", as.numeric(x[2]), "-", as.numeric(x[3]))
   }
-  
+
   if(missing(regions_list)){
     if(!missing(regions_bed)){
       regions = apply(regions_bed, 1, bed2region)
@@ -68,38 +70,39 @@ get_ssm_by_regions = function(these_sample_ids = NULL,
   }
 
   if(verbose){
-    print(regions)  
+    print(regions)
   }
-  
+
   if(missing(maf_data)){
     #warn/notify the user what version of this function they are using
     message("Using the bundled SSM calls (.maf) calls in GAMBLR.data...")
-    
+
     #get samples with the dedicated helper function
     metadata = id_ease(these_samples_metadata = these_samples_metadata,
                        these_sample_ids = these_sample_ids,
                        verbose = verbose,
                        this_seq_type = this_seq_type)
-    
+
     region_mafs = lapply(regions, function(x){GAMBLR.data::get_ssm_by_region(region = x,
                                                                              these_samples_metadata = metadata,
                                                                              this_seq_type = this_seq_type,
                                                                              streamlined = streamlined,
-                                                                             projection = projection, 
+                                                                             projection = projection,
                                                                              min_read_support = min_read_support,
+                                                                             mode = mode,
                                                                              verbose = FALSE, #force to FALSE, suppressing noisy output
                                                                              ...)})
   }else{
     region_mafs = lapply(regions, function(x){GAMBLR.data::get_ssm_by_region(region = x,
                                                                              maf_data = maf_data,
                                                                              streamlined = streamlined,
-                                                                             projection = projection, 
+                                                                             projection = projection,
                                                                              min_read_support = min_read_support,
                                                                              verbose = FALSE, #force to FALSE, suppressing noisy output
                                                                              ...)})
-    
+
   }
-  
+
   #deal with region names
   if(!use_name_column){
     rn = regions
@@ -107,17 +110,17 @@ get_ssm_by_regions = function(these_sample_ids = NULL,
     if(missing(regions_bed)){
       stop("use_name_column = TRUE is only available if regions are provided with `regions_bed`")
     }else{
-      rn = regions_bed[["name"]] 
+      rn = regions_bed[["name"]]
     }
   }
-  
+
   #add the region name to the to-be-returned maf
   tibbled_data = tibble(region_mafs, region_name = rn)
-  
+
   #unnest tibbled data
   unnested_df = tibbled_data %>%
     unnest_longer(region_mafs)
-  
+
   if(streamlined){
     unlisted_df = mutate(unnested_df, start = region_mafs$Start_Position, sample_id = region_mafs$Tumor_Sample_Barcode) %>%
       dplyr::select(start, sample_id, region_name)

--- a/R/get_ssm_by_samples.R
+++ b/R/get_ssm_by_samples.R
@@ -2,7 +2,7 @@
 #'
 #' @description Get the SSMs (i.e. load MAF) for a single sample or a collection fo samples.
 #'
-#' @details Retrieve a maf for a specific sample or a set of samples. 
+#' @details Retrieve a maf for a specific sample or a set of samples.
 #' Either specify the sample IDs of interest with `these_sample_ids`.
 #' Or a metadata table subset to the sample IDs of interest with `these_samples_metadata`.
 #'
@@ -12,6 +12,7 @@
 #' If not provided and these_sample_ids is also not provided, the function will return SSM for all samples from the specified seq_type in the bundled metadata.
 #' @param this_seq_type Default is genome.
 #' @param projection The projection genome build. Supports hg38 and grch37.
+#' @param tool_name Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.
 #' @param these_genes A vector of genes to subset ssm to.
 #' @param min_read_support Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).
 #' @param basic_columns Return first 43 columns of MAF rather than full details. Default is TRUE.
@@ -22,86 +23,90 @@
 #' @return data frame in MAF format.
 #'
 #' @import dplyr
-#' 
+#'
 #' @export
 #'
 #' @examples
 #' #load packages
 #' library(dplyr)
-#' 
+#'
 #' #return a MAF for DLBCL cell line
-#' cell_line_meta = GAMBLR.data::sample_data$meta %>% 
+#' cell_line_meta = GAMBLR.data::sample_data$meta %>%
 #'   dplyr::filter(cohort == "DLBCL_cell_lines")
-#'   
+#'
 #' dlbcl_maf = get_ssm_by_samples(these_samples_metadata = cell_line_meta)
-#' 
+#'
 get_ssm_by_samples <- function(these_sample_ids = NULL,
                                these_samples_metadata = NULL,
                                this_seq_type = "genome",
                                projection = "grch37",
+                               tool_name = "slms-3",
                                these_genes,
                                min_read_support = 3,
                                basic_columns = TRUE,
                                maf_cols = NULL,
                                verbose = FALSE,
                                ...){
-  
+
   #warn/notify the user what version of this function they are using
   message("Using the bundled SSM calls (.maf) calls in GAMBLR.data...")
-  
+
   #check if any invalid parameters are provided
   check_excess_params(...)
-  
+
   #get samples with the dedicated helper function
   metadata = id_ease(these_samples_metadata = these_samples_metadata,
                      these_sample_ids = these_sample_ids,
                      verbose = verbose,
                      this_seq_type = this_seq_type)
-  
+
   sample_ids = metadata$sample_id
-  
+
   #get valid projections
   valid_projections = grep("meta", names(GAMBLR.data::sample_data), value = TRUE, invert = TRUE)
-  
+
   #return SSMs based on the selected projection
   if(projection %in% valid_projections){
     sample_ssm = GAMBLR.data::sample_data[[projection]]$maf %>%
       dplyr::filter(Tumor_Sample_Barcode %in% sample_ids)
+    sample_ssm <- sample_ssm %>%
+        filter((tolower(!!sym("Pipeline")) == tool_name))
+    return(sample_ssm)
   }else{
     stop(paste("please provide a valid projection. The following are available:",
                paste(valid_projections,collapse=", ")))
   }
-  
+
   #drop poorly supported reads
   sample_ssm = dplyr::filter(sample_ssm, t_alt_count >= min_read_support)
-  
+
   if(!missing(these_genes)){
     sample_ssm = sample_ssm %>%
       dplyr::filter(Hugo_Symbol %in% these_genes)
   }
-  
+
   #subset maf to only include first 43 columns (default)
   if(basic_columns){
     sample_ssm = dplyr::select(sample_ssm, c(1:45))
   }
-  
+
   #subset maf to a specific set of columns (defined in maf_cols)
   if(!is.null(maf_cols) && !basic_columns){
     sample_ssm = dplyr::select(sample_ssm, all_of(maf_cols))
   }
-  
+
   return(sample_ssm)
 }
 
 
 #' @rdname get_ssm_by_samples
-#' 
+#'
 #' @examples
 #' #basic usage, using a single sample ID
 #' dohh2_maf = get_ssm_by_sample(this_sample_id = "DOHH-2")
-#' 
+#'
 #' @export
-#' 
+#'
 get_ssm_by_sample = function(this_sample_id = NULL,
                              these_samples_metadata = NULL,
                              this_seq_type = "genome",
@@ -112,7 +117,7 @@ get_ssm_by_sample = function(this_sample_id = NULL,
                              maf_cols = NULL,
                              verbose = FALSE,
                              ...){
-  
+
   get_ssm_by_samples(these_sample_ids = this_sample_id,
                      these_samples_metadata = these_samples_metadata,
                      this_seq_type = this_seq_type,

--- a/R/get_ssm_by_samples.R
+++ b/R/get_ssm_by_samples.R
@@ -99,6 +99,10 @@ get_ssm_by_samples <- function(these_sample_ids = NULL,
     sample_ssm = dplyr::select(sample_ssm, all_of(maf_cols))
   }
 
+  # Handle possible duplicates
+  sample_ssm <- sample_ssm %>%
+    distinct
+
   return(sample_ssm)
 }
 

--- a/R/get_ssm_by_samples.R
+++ b/R/get_ssm_by_samples.R
@@ -68,10 +68,14 @@ get_ssm_by_samples <- function(these_sample_ids = NULL,
   #return SSMs based on the selected projection
   if(projection %in% valid_projections){
     sample_ssm = GAMBLR.data::sample_data[[projection]]$maf %>%
-      dplyr::filter(Tumor_Sample_Barcode %in% sample_ids)
-    sample_ssm <- sample_ssm %>%
-        filter((tolower(!!sym("Pipeline")) == tool_name))
-    return(sample_ssm)
+        dplyr::filter(Tumor_Sample_Barcode %in% sample_ids) %>%
+        dplyr::filter((tolower(!!sym("Pipeline")) == tool_name))
+    sample_ssm <- bind_rows(
+        sample_ssm,
+        GAMBLR.data::sample_data[[projection]]$ashm %>%
+            dplyr::filter(Tumor_Sample_Barcode %in% sample_ids) %>%
+            dplyr::filter((tolower(!!sym("Pipeline")) == tool_name))
+    )
   }else{
     stop(paste("please provide a valid projection. The following are available:",
                paste(valid_projections,collapse=", ")))

--- a/data-raw/assemble_bundled_data.R
+++ b/data-raw/assemble_bundled_data.R
@@ -534,6 +534,34 @@ left_join(coding_maf)
 
 dim(sample_data$grch37$maf)
 
+
+# Add aSHM mutations for the already released samples
+grch37_ashm <- get_ssm_by_regions(
+    regions_bed = grch37_ashm_regions,
+    streamlined = FALSE,
+    basic_columns = TRUE
+)
+grch37_ashm <- grch37_ashm %>%
+    filter(Tumor_Sample_Barcode %in% sample_data$meta$Tumor_Sample_Barcode)
+
+grch37_ashm <- grch37_ashm %>% mutate(Pipeline = "SLMS-3")
+
+hg38_ashm <- get_ssm_by_regions(
+    regions_bed = hg38_ashm_regions,
+    projection = "hg38",
+    streamlined = FALSE,
+    basic_columns = TRUE
+)
+hg38_ashm <- hg38_ashm %>%
+    filter(Tumor_Sample_Barcode %in% sample_data$meta$Tumor_Sample_Barcode)
+
+hg38_ashm <- hg38_ashm %>% mutate(Pipeline = "SLMS-3")
+
+
+sample_data$grch37$ashm <- grch37_ashm
+sample_data$hg38$ashm <- hg38_ashm
+
+
 setwd("~/my_dir/repos/GAMBLR.data/")
 
 usethis::use_data(

--- a/data-raw/assemble_bundled_data.R
+++ b/data-raw/assemble_bundled_data.R
@@ -496,7 +496,7 @@ coding_maf <- bind_rows(
 
 dim(GAMBLR.data::sample_data$hg38$maf)
 
-sample_data$hg38$maf <- GAMBLR.data::sample_data$hg38$maf %>%
+sample_data$hg38$maf <- sample_data$hg38$maf %>%
 left_join(coding_maf)
 
 this_study_samples <- GAMBLR.data::sample_data$meta %>%
@@ -561,6 +561,52 @@ hg38_ashm <- hg38_ashm %>% mutate(Pipeline = "SLMS-3")
 sample_data$grch37$ashm <- grch37_ashm
 sample_data$hg38$ashm <- hg38_ashm
 
+
+# Now add the SLMS-3 calls in both projections for those samples that
+# are bundled as publication data
+publication_samples_grch37 <- sample_data$grch37$maf %>%
+    filter(Pipeline == "Publication") %>%
+    pull(Tumor_Sample_Barcode) %>%
+    unique %>% sort
+
+publication_samples_hg38 <- sample_data$hg38$maf %>%
+    filter(Pipeline == "Publication") %>%
+    pull(Tumor_Sample_Barcode) %>%
+    unique %>% sort
+
+publication_samples <- c(
+    publication_samples_grch37,
+    publication_samples_hg38
+)
+
+grch37 <- get_ssm_by_samples(
+    these_sample_ids = publication_samples,
+    basic_columns = FALSE,
+    these_genes = all_lymphoma_genes
+)
+
+sample_data$grch37$maf <- grch37 %>%
+    mutate(Pipeline = "SLMS-3") %>%
+    select(colnames(sample_data$grch37$maf)) %>%
+    bind_rows(
+        .,
+        sample_data$grch37$maf
+    )
+
+hg38 <- get_ssm_by_samples(
+    these_sample_ids = publication_samples,
+    projection = "hg38",
+    basic_columns = FALSE,
+    these_genes = all_lymphoma_genes
+)
+
+sample_data$hg38$maf <- hg38 %>%
+    mutate(Pipeline = "SLMS-3") %>%
+    select(colnames(sample_data$hg38$maf)) %>%
+    bind_rows(
+        .,
+        sample_data$hg38$maf
+    )
 
 setwd("~/my_dir/repos/GAMBLR.data/")
 

--- a/man/get_ssm_by_patients.Rd
+++ b/man/get_ssm_by_patients.Rd
@@ -9,6 +9,7 @@ get_ssm_by_patients(
   these_samples_metadata,
   projection = "grch37",
   this_seq_type = "genome",
+  tool_name = "slms-3",
   min_read_support = 3,
   basic_columns = TRUE,
   maf_cols = NULL,
@@ -26,6 +27,8 @@ If the vector of patient IDs is missing (\code{these_patient_ids}), this functio
 \item{projection}{Obtain variants projected to this reference (one of grch37 or hg38). Default is grch37.}
 
 \item{this_seq_type}{The seq type you want results for. Default is "genome".}
+
+\item{tool_name}{Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.}
 
 \item{min_read_support}{Subset returned variants to a set minimum read support. Default is 3.}
 
@@ -60,10 +63,10 @@ library(dplyr)
 my_patient = get_ssm_by_patients(these_patient_ids = "DOHH-2")
 
 #using a subset metadata tablee to retreive patient SSMs
-cell_line_meta = GAMBLR.data::sample_data$meta \%>\% 
+cell_line_meta = GAMBLR.data::sample_data$meta \%>\%
  dplyr::filter(cohort == "DLBCL_cell_lines")
- 
-patient_maf = get_ssm_by_patients(these_samples_metadata = cell_line_meta, 
+
+patient_maf = get_ssm_by_patients(these_samples_metadata = cell_line_meta,
                                   this_seq_type = "genome")
 
 }

--- a/man/get_ssm_by_region.Rd
+++ b/man/get_ssm_by_region.Rd
@@ -45,7 +45,7 @@ i.e the following parameters are ignored; \code{these_samples_metadata}, \code{t
 
 \item{this_seq_type}{The seq_type you want back, default is genome.}
 
-\item{mode}{Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".}
+\item{mode}{Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.}
 
 \item{min_read_support}{Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).}
 

--- a/man/get_ssm_by_region.Rd
+++ b/man/get_ssm_by_region.Rd
@@ -15,6 +15,7 @@ get_ssm_by_region(
   streamlined = FALSE,
   projection = "grch37",
   this_seq_type = "genome",
+  mode = "slms-3",
   min_read_support = 3,
   verbose = FALSE,
   ...
@@ -43,6 +44,8 @@ i.e the following parameters are ignored; \code{these_samples_metadata}, \code{t
 \item{projection}{Obtain variants projected to this reference (one of grch37 or hg38).}
 
 \item{this_seq_type}{The seq_type you want back, default is genome.}
+
+\item{mode}{Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".}
 
 \item{min_read_support}{Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).}
 

--- a/man/get_ssm_by_regions.Rd
+++ b/man/get_ssm_by_regions.Rd
@@ -32,7 +32,7 @@ If not provided (and if \code{these_sample_ids} is not provided), the function w
 
 \item{this_seq_type}{The this_seq_type you want back, default is genome.}
 
-\item{mode}{Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".}
+\item{mode}{Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.}
 
 \item{regions_list}{A vector of regions in the chr:start-end format to restrict the returned SSM calls to.}
 

--- a/man/get_ssm_by_regions.Rd
+++ b/man/get_ssm_by_regions.Rd
@@ -9,6 +9,7 @@ get_ssm_by_regions(
   these_samples_metadata = NULL,
   maf_data,
   this_seq_type = "genome",
+  mode = "slms-3",
   regions_list,
   regions_bed,
   streamlined = TRUE,
@@ -30,6 +31,8 @@ i.e the following parameters are ignored; \code{these_samples_metadata}, \code{t
 If not provided (and if \code{these_sample_ids} is not provided), the function will return all samples from the specified seq_type in the metadata.}
 
 \item{this_seq_type}{The this_seq_type you want back, default is genome.}
+
+\item{mode}{Accepts 2 options of "slms-3" and "publication" to indicate which variant calls to use. Default is "slms-3".}
 
 \item{regions_list}{A vector of regions in the chr:start-end format to restrict the returned SSM calls to.}
 
@@ -60,7 +63,7 @@ This function internally calls \link{get_ssm_by_region} to retrieve SSM calls fo
 }
 \examples{
 #basic usage, adding custom names from bundled ashm data frame
-regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, 
+regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions,
   name = paste(gene, region, sep = "_"))
 
 ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed,

--- a/man/get_ssm_by_samples.Rd
+++ b/man/get_ssm_by_samples.Rd
@@ -10,6 +10,7 @@ get_ssm_by_samples(
   these_samples_metadata = NULL,
   this_seq_type = "genome",
   projection = "grch37",
+  tool_name = "slms-3",
   these_genes,
   min_read_support = 3,
   basic_columns = TRUE,
@@ -41,6 +42,8 @@ If not provided and these_sample_ids is also not provided, the function will ret
 
 \item{projection}{The projection genome build. Supports hg38 and grch37.}
 
+\item{tool_name}{Optionally specify which tool to report variant from. The default is slms-3, also supports "publication" to return the exact variants as reported in the original papers.}
+
 \item{these_genes}{A vector of genes to subset ssm to.}
 
 \item{min_read_support}{Only returns variants with at least this many reads in t_alt_count (for cleaning up augmented MAFs).}
@@ -71,9 +74,9 @@ Or a metadata table subset to the sample IDs of interest with \code{these_sample
 library(dplyr)
 
 #return a MAF for DLBCL cell line
-cell_line_meta = GAMBLR.data::sample_data$meta \%>\% 
+cell_line_meta = GAMBLR.data::sample_data$meta \%>\%
   dplyr::filter(cohort == "DLBCL_cell_lines")
-  
+
 dlbcl_maf = get_ssm_by_samples(these_samples_metadata = cell_line_meta)
 
 #basic usage, using a single sample ID


### PR DESCRIPTION
This PR resolves issues:
- #52 
- #51 
The corresponding functions were also adjusted to support same argument as the parent version in GAMBLR.results and return the correct variants.