### PR TITLE
Fix id_ease when metadata and seq_type are provided

### DIFF
--- a/R/get_gambl_metadata.R
+++ b/R/get_gambl_metadata.R
@@ -7,7 +7,7 @@
 #' It relies on the bundled metadata in this package.
 #'
 #' @param seq_type_filter Specify the seq type you want to return metadata for.
-#' Default is both genome and capture (all samples).
+#' Default is "genome".
 #' @param ... Any additional parameters.
 #'
 #' @return A data frame with metadata, tailored for user without GSC access.
@@ -56,13 +56,13 @@
 #' #return metadata for genome and capture samples
 #' all_meta = get_gambl_metadata(seq_type_filter = c("genome", "capture"))
 #'
-get_gambl_metadata = function(seq_type_filter = c("genome", "capture"),
+get_gambl_metadata = function(seq_type_filter = "genome",
                               ...){
 
   #check if any invalid parameters are provided
   check_excess_params(...)
 
   message("Using the bundled metadata in GAMBLR.data...")
-  return(GAMBLR.data::gambl_metadata %>%
+  return(GAMBLR.data::sample_data$meta %>%
            dplyr::filter(seq_type %in% seq_type_filter))
 }

--- a/R/id_ease.R
+++ b/R/id_ease.R
@@ -1,4 +1,3 @@
-
 #' @title ID Ease
 #'
 #' @aliases id_ease, id ease
@@ -8,7 +7,7 @@
 #'
 #' @details This function can take sample IDs as a vector of characters, or a metadata table in data frame format.
 #' If no sample IDs are provided to the function, the function will operate on all gambl sample IDs available for the given seq type.
-#' It is highly recommended to run this function with `verbose = TRUE` (default). 
+#' It is highly recommended to run this function with `verbose = TRUE`. 
 #' Since this will not only improve the overall logic on how the function operates.
 #' But also might help with debugging functions that are internally calling this function.
 #' The function also performs sanity checks and notifies the user if any of the requested sample IDs are not found in the metadata.
@@ -55,9 +54,29 @@ id_ease = function(these_samples_metadata = NULL,
     metadata = GAMBLR.data::get_gambl_metadata(seq_type_filter = this_seq_type)
   }else{
     if(verbose){
-      message("id_ease: Metadata is provided...") 
+      message("id_ease: Metadata is provided and samples of the selected seq type are kept...") 
     }
-    metadata = these_samples_metadata
+    metadata = dplyr::filter(these_samples_metadata, seq_type %in% this_seq_type)
+    not_seq_type = setdiff(these_samples_metadata$sample_id, metadata$sample_id)
+    if(length(not_seq_type) > 0){
+      not_seq_type_msg = gettextf("id_ease: WARNING! %i samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument.",
+                                  length(not_seq_type))
+      if(verbose){
+        max_to_show <- 100
+        if( length(not_seq_type) > max_to_show ){
+          not_seq_type_msg = gettextf("%s Their first %i IDs are:", not_seq_type_msg, 
+                                      max_to_show)
+          not_seq_type = head(not_seq_type, max_to_show)
+        }else{
+          not_seq_type_msg = gettextf("%s Their IDs are:", not_seq_type_msg)
+        }
+        message(not_seq_type_msg)
+        print(not_seq_type)
+      }else{
+        not_seq_type_msg = gettextf("%s Use `verbose = TRUE` to see their IDs.", not_seq_type_msg)
+        message(not_seq_type_msg)
+      }
+    }
   }
   
   #ensure metadata is subset to specified sample IDs

--- a/man/get_gambl_metadata.Rd
+++ b/man/get_gambl_metadata.Rd
@@ -4,11 +4,11 @@
 \alias{get_gambl_metadata}
 \title{Get GAMBL Metadata.}
 \usage{
-get_gambl_metadata(seq_type_filter = c("genome", "capture"), ...)
+get_gambl_metadata(seq_type_filter = "genome", ...)
 }
 \arguments{
 \item{seq_type_filter}{Specify the seq type you want to return metadata for.
-Default is both genome and capture (all samples).}
+Default is "genome".}
 
 \item{...}{Any additional parameters.}
 }

--- a/man/id_ease.Rd
+++ b/man/id_ease.Rd
@@ -34,7 +34,7 @@ and metadata (these_samples_metadata).
 \details{
 This function can take sample IDs as a vector of characters, or a metadata table in data frame format.
 If no sample IDs are provided to the function, the function will operate on all gambl sample IDs available for the given seq type.
-It is highly recommended to run this function with \code{verbose = TRUE} (default).
+It is highly recommended to run this function with \code{verbose = TRUE}.
 Since this will not only improve the overall logic on how the function operates.
 But also might help with debugging functions that are internally calling this function.
 The function also performs sanity checks and notifies the user if any of the requested sample IDs are not found in the metadata.


### PR DESCRIPTION
In this PR, id_ease is changed to use `this_seq_type` to filter samples from user-provided metadata.

I also added a warning message to let the user know the filtering. Moreover, If the user wants to know the sample ids that were filtered out, they are instructed to set `verbose = TRUE`. However, since it may be the case that several sample ids are filtered out and then you get an overcrowded console, the function limits its message to show a maximum of 100 sample ids. 

- verbose = FALSE
```
> my_meta = filter(sample_data$meta, pathology %in% c("BL", "DLBCL", "FL"))
> dim(my_meta)
[1] 2406   12
> table(my_meta$seq_type)

capture  genome 
   1702     704 
> 
> meta2 = id_ease(these_samples_metadata = my_meta,
+                 these_sample_ids = NULL,
+                 verbose = FALSE,
+                 this_seq_type = "capture")
id_ease: WARNING! 704 samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument. Use `verbose = TRUE` to see their IDs.
> dim(meta2)
[1] 1702   12
> table(meta2$seq_type)

capture 
   1702 
```

- verbose = TRUE
```
> meta2 = id_ease(these_samples_metadata = my_meta,
+                 these_sample_ids = NULL,
+                 verbose = TRUE,
+                 this_seq_type = "capture")
id_ease: Metadata is provided and samples of the selected seq type are kept...
id_ease: WARNING! 704 samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument. Their first 100 IDs are:
  [1] "Akata"                     "BL2"                       "BL30"                     
  [4] "BL41"                      "BL70"                      "BLGSP-71-06-00001-01A-11D"
  [7] "BLGSP-71-06-00002-01C-01D" "BLGSP-71-06-00004-01A-11D" "BLGSP-71-06-00005-01A-21D"
 [10] "BLGSP-71-06-00007-01A-11D" "BLGSP-71-06-00008-01A-11D" "BLGSP-71-06-00011-01A-11D"
 [13] "BLGSP-71-06-00012-01A-11D" "BLGSP-71-06-00013-01B-11D" "BLGSP-71-06-00015-01A-21D"
 [16] "BLGSP-71-06-00016-01A-01D" "BLGSP-71-06-00019-01A-11D" "BLGSP-71-06-00020-01A-11D"
 [19] "BLGSP-71-06-00071-01B-11D" "BLGSP-71-06-00072-01A-11D" "BLGSP-71-06-00074-01A-11D"
 [22] "BLGSP-71-06-00076-01A-11D" "BLGSP-71-06-00078-01A-11D" "BLGSP-71-06-00080-01A-11D"
 [25] "BLGSP-71-06-00081-01D-12D" "BLGSP-71-06-00084-01A-01D" "BLGSP-71-06-00085-01A-01D"
 [28] "BLGSP-71-06-00086-01A-01D" "BLGSP-71-06-00087-01A-01D" "BLGSP-71-06-00088-01A-01D"
 [31] "BLGSP-71-06-00089-01A-01D" "BLGSP-71-06-00090-01A-01D" "BLGSP-71-06-00093-01A-01D"
 [34] "BLGSP-71-06-00094-01A-01D" "BLGSP-71-06-00095-01A-01D" "BLGSP-71-06-00098-01A-01D"
 [37] "BLGSP-71-06-00137-01A-01D" "BLGSP-71-06-00139-01A-01E" "BLGSP-71-06-00142-01A-01D"
 [40] "BLGSP-71-06-00144-01A-01D" "BLGSP-71-06-00146-01C-01E" "BLGSP-71-06-00148-01A-01D"
 [43] "BLGSP-71-06-00149-01A-01D" "BLGSP-71-06-00154-01A-01D" "BLGSP-71-06-00155-01A-01D"
 [46] "BLGSP-71-06-00158-01A-01D" "BLGSP-71-06-00159-01A-01D" "BLGSP-71-06-00160-01A-03D"
 [49] "BLGSP-71-06-00162-01A-01D" "BLGSP-71-06-00164-01C-01D" "BLGSP-71-06-00165-01A-01D"
 [52] "BLGSP-71-06-00166-01B-01D" "BLGSP-71-06-00169-01B-01D" "BLGSP-71-06-00171-01A-01D"
 [55] "BLGSP-71-06-00172-01A-01D" "BLGSP-71-06-00174-01A-01D" "BLGSP-71-06-00177-01A-01D"
 [58] "BLGSP-71-06-00178-01A-01D" "BLGSP-71-06-00180-01A-01D" "BLGSP-71-06-00190-01B-01D"
 [61] "BLGSP-71-06-00251-01C-01D" "BLGSP-71-06-00252-01A-01D" "BLGSP-71-06-00253-01A-01D"
 [64] "BLGSP-71-06-00255-01C-01D" "BLGSP-71-06-00277-01A-01D" "BLGSP-71-06-00280-01A-01D"
 [67] "BLGSP-71-06-00281-01A-01D" "BLGSP-71-06-00283-01A-01D" "BLGSP-71-06-00285-01A-01D"
 [70] "BLGSP-71-06-00286-01A-01D" "BLGSP-71-06-00288-01A-01D" "BLGSP-71-08-00022-01A-01D"
 [73] "BLGSP-71-08-00023-01A-01D" "BLGSP-71-08-00025-01A-01D" "BLGSP-71-08-00033-01A-01D"
 [76] "BLGSP-71-08-00035-01A-01D" "BLGSP-71-08-00036-01A-01D" "BLGSP-71-08-00038-01A-01D"
 [79] "BLGSP-71-08-00041-01A-01D" "BLGSP-71-08-00042-01B-01E" "BLGSP-71-08-00050-01A-11D"
 [82] "BLGSP-71-08-00191-01A-11D" "BLGSP-71-08-00194-01A-11D" "BLGSP-71-08-00197-01A-11D"
 [85] "BLGSP-71-08-00199-01A-11D" "BLGSP-71-08-00200-01A-11D" "BLGSP-71-08-00204-01A-11D"
 [88] "BLGSP-71-08-00205-01A-11D" "BLGSP-71-08-00206-01A-11D" "BLGSP-71-08-00207-01A-11D"
 [91] "BLGSP-71-08-00210-01A-11D" "BLGSP-71-08-00212-01A-11D" "BLGSP-71-08-00213-01A-11D"
 [94] "BLGSP-71-08-00217-01A-01E" "BLGSP-71-08-00219-01A-11D" "BLGSP-71-08-00432-01B-01E"
 [97] "BLGSP-71-17-00232-01B-13E" "BLGSP-71-17-00234-01A-01E" "BLGSP-71-17-00235-01B-01E"
[100] "BLGSP-71-17-00237-01A-01E"
id_ease: No sample IDs provided, all sample IDs in the metadata will be kept...
id_ease: Returning metadata for 1702 samples...
```